### PR TITLE
API & Team management updates

### DIFF
--- a/docs/api/get-started-content.md
+++ b/docs/api/get-started-content.md
@@ -1,13 +1,20 @@
 ---
-id: get-started
-title: Get started with the Quant API
-sidebar_label: Get started
+id: get-started-content
+title: Get started with the Content API
+sidebar_label: Get started (Content)
 ---
 
+:::tip
+The full API schema is available at https://docs.api.quantcdn.io
+:::
+
+## Overview
+
+The Content API provides an interface to create and manage content and revisions. 
 
 ## Make a request
 
-All API requests must be directed to the `https://api.quantcdn.io/v1/`. The path is prefixed with the API version. If backwards-breaking changed are introduced into the API the version number will be bumped, old versions of the API will be maintained and deprecated with plenty of notice. You will need to add specific headers to each request to ensure that the API endpoint can correctly identify you.
+All API requests must be directed to the `https://api.quantcdn.io/v1/`. The path is prefixed with the API version. If backwards-breaking changes are introduced into the API the version number will be bumped, old versions of the API will be maintained and deprecated with plenty of notice. You will need to add specific headers to each request to ensure that the API endpoint can correctly identify you.
 
 In curl a request will look like:
 
@@ -64,7 +71,7 @@ The Quant API will scan your markup and identify assets. It will respond to your
 
 #### Custom headers
 
-You may optionally provide custom headers along with the content payload. This allows fine-grained control of the headers that are emitted for each individual piece of content. Simply include key/value pairs under the `header` key:
+You may optionally provide custom headers along with the content payload. This allows fine-grained control of the headers that are emitted for each individual piece of content. Simply include key/value pairs under the `headers` key:
 
 ```json
 {

--- a/docs/api/get-started-content.md
+++ b/docs/api/get-started-content.md
@@ -14,7 +14,7 @@ The Content API provides an interface to create and manage content and revisions
 
 ## Make a request
 
-All API requests must be directed to the `https://api.quantcdn.io/v1/`. The path is prefixed with the API version. If backwards-breaking changes are introduced into the API the version number will be bumped, old versions of the API will be maintained and deprecated with plenty of notice. You will need to add specific headers to each request to ensure that the API endpoint can correctly identify you.
+All API requests must be directed to the `https://api.quantcdn.io/v1/` endpoint. The path is prefixed with the API version. If backwards-breaking changes are introduced into the API the version number will be bumped. Old versions of the API will be maintained and deprecated with plenty of notice. You will need to add specific headers to each request to ensure that the API endpoint can correctly identify you.
 
 In curl a request will look like:
 

--- a/docs/api/get-started-projects.md
+++ b/docs/api/get-started-projects.md
@@ -1,0 +1,36 @@
+---
+id: get-started-projects
+title: Get started with the Project API
+sidebar_label: Get started (Projects)
+---
+
+:::tip
+The full API schema is available at https://docs.dashboard.quantcdn.io
+:::
+
+## Overview
+
+The projects API provides an interface to create and manage projects and domains. 
+
+## Create a scoped token
+
+Tokens can be generated from the [Quant Dashboard](https://dashboard.quantcdn.io/profile). If you belong to multiple organizations you may scope the token to select organizations only.
+
+The token will inherit your user role and permissions within organizations.
+
+## Make a request
+
+All API requests must be directed to the `https://dashboard.quantcdn.io/api/v1/`. The path is prefixed with the API version. If backwards-breaking changes are introduced into the API the version number will be bumped, old versions of the API will be maintained and deprecated with plenty of notice. You will need to add specific headers to each request to ensure that the API endpoint can correctly identify you.
+
+Provide the generated token as an `Authorization: Bearer ...` token in the request. An example via curl will look like:
+
+```
+curl https://dashboard.quantcdn.io/api/v1/organisations -H "Authorization: Bearer [token]]"
+```
+
+Read the full [schema documentation](https://docs.dashboard.quantcdn.io) to better understand how to interact with the API.
+
+
+:::note
+Not all dashboard functionality is available via API. Please raise a feature request if your organization require additional access.
+:::

--- a/docs/api/get-started-projects.md
+++ b/docs/api/get-started-projects.md
@@ -32,5 +32,5 @@ Read the full [schema documentation](https://docs.dashboard.quantcdn.io) to bett
 
 
 :::note
-Not all dashboard functionality is available via API. Please raise a feature request if your organization require additional access.
+Not all dashboard functionality is available via API. Please raise a feature request if your organization requires additional access.
 :::

--- a/docs/api/get-started-projects.md
+++ b/docs/api/get-started-projects.md
@@ -20,7 +20,7 @@ The token will inherit your user role and permissions within organizations.
 
 ## Make a request
 
-All API requests must be directed to the `https://dashboard.quantcdn.io/api/v1/`. The path is prefixed with the API version. If backwards-breaking changes are introduced into the API the version number will be bumped, old versions of the API will be maintained and deprecated with plenty of notice. You will need to add specific headers to each request to ensure that the API endpoint can correctly identify you.
+All API requests must be directed to the `https://dashboard.quantcdn.io/api/v1/` endpoint. The path is prefixed with the API version. If backwards-breaking changes are introduced into the API the version number will be bumped. Old versions of the API will be maintained and deprecated with plenty of notice. You will need to add specific headers to each request to ensure that the API endpoint can correctly identify you.
 
 Provide the generated token as an `Authorization: Bearer ...` token in the request. An example via curl will look like:
 

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -10,7 +10,7 @@ This can be useful for more control over structured data (e.g title/summary/cont
 
 ## Using the Search API
 
-See the [Getting Started](/docs/api/get-started) section first to ensure you can authenticate and make successful API connections.
+See the [Getting Started](/docs/api/get-started-content) section first to ensure you can authenticate and make successful API connections.
 
 ### Check index status
 

--- a/docs/dashboard/team.md
+++ b/docs/dashboard/team.md
@@ -20,26 +20,25 @@ You may revoke the invitation before they accept.
 
 ### Accepting or declining an invitation
 
-Users will receive an email prompting them to join. If they already have an account they can click the link and login to accept, otherwise they must first register.
+Users will receive an email prompting them to join. If they already have an account, they can click the link and login to accept; otherwise they must first register.
 
-Inivitations and existing memberships are also listed from the profile page - they can be accepted or declined from this screen.
+Inivitations and existing memberships are also listed from the profile page. They can be accepted or declined from this screen.
 
 ## Change active organizations
 
-Click on your profile icon (upper right) to switch between organizations or your own private account.
+Click on your profile icon (upper right) to switch between organizations and your own private account.
 
-Projects are scoped to organizations. Once you have activated an organization the projects list (upper left) can be used to toggle the active project.
+Projects are scoped to organizations. Once you have activated an organization, the projects list (upper left) can be used to toggle the active project.
 
 ### Enforcing two-factor authentication
 
 The organization owner can enforce two-factor authentication by checking the box at the top of the page.
 
-Users will be prompted to complete the two-factor authentation enrolment before they can undertake any further action within the dashboard.
+Users will be prompted to complete the two-factor authentation set up before they can undertake any further action within the dashboard.
 
 ### Changing roles
 
 To change an existing user role you must have an organization owner or administrator remove and re-add you with the appropriate role.
-
 
 ### Role permissions
 
@@ -85,4 +84,4 @@ To change an existing user role you must have an organization owner or administr
 | Enforce TFA                |             |                  |           |               | ✅                  |
 | Reset team member TFA¹     |             |                  |           |               | ✅                  |
 
-¹ via support desk. Additional verification processes apply.
+¹ via the support desk. Additional verification processes apply.

--- a/docs/dashboard/team.md
+++ b/docs/dashboard/team.md
@@ -38,7 +38,7 @@ Users will be prompted to complete the two-factor authentation set up before the
 
 ### Changing roles
 
-To change an existing user role you must have an organization owner or administrator remove and re-add you with the appropriate role.
+To change an existing user role an organization owner or administrator must remove and re-add you with the appropriate role.
 
 ### Role permissions
 

--- a/docs/dashboard/team.md
+++ b/docs/dashboard/team.md
@@ -12,13 +12,13 @@ Navigate to the "Team" section of the dashboard to see all current members and t
 
 Only organization owners or administators have permission to manage team members.
 
-### Inviting new members
+## Inviting new members
 
 Click on the "Invite" button and provide name, email and role to add users to the organization.
 
 You may revoke the invitation before they accept.
 
-### Accepting or declining an invitation
+## Accepting or declining an invitation
 
 Users will receive an email prompting them to join. If they already have an account, they can click the link and login to accept; otherwise they must first register.
 
@@ -30,17 +30,17 @@ Click on your profile icon (upper right) to switch between organizations and you
 
 Projects are scoped to organizations. Once you have activated an organization, the projects list (upper left) can be used to toggle the active project.
 
-### Enforcing two-factor authentication
+## Enforcing two-factor authentication
 
 The organization owner can enforce two-factor authentication by checking the box at the top of the page.
 
 Users will be prompted to complete the two-factor authentation set up before they can undertake any further action within the dashboard.
 
-### Changing roles
+## Changing roles
 
 To change an existing user role an organization owner or administrator must remove and re-add you with the appropriate role.
 
-### Role permissions
+## Role permissions
 
 |                            | Developer   | Content manager | Read only | Administrator | Organization owner |
 | ----------- | :----: | :----: | :----: | :----: | :----: |

--- a/docs/dashboard/team.md
+++ b/docs/dashboard/team.md
@@ -1,0 +1,88 @@
+---
+id: team
+title: Team management
+sidebar_label: Team management
+---
+
+## Overview
+
+Organization subscriptions allow multiple team members to belong to a single organization. Roles can be assigned to control access.
+
+Navigate to the "Team" section of the dashboard to see all current members and their roles.
+
+Only organization owners or administators have permission to manage team members.
+
+### Inviting new members
+
+Click on the "Invite" button and provide name, email and role to add users to the organization.
+
+You may revoke the invitation before they accept.
+
+### Accepting or declining an invitation
+
+Users will receive an email prompting them to join. If they already have an account they can click the link and login to accept, otherwise they must first register.
+
+Inivitations and existing memberships are also listed from the profile page - they can be accepted or declined from this screen.
+
+## Change active organizations
+
+Click on your profile icon (upper right) to switch between organizations or your own private account.
+
+Projects are scoped to organizations. Once you have activated an organization the projects list (upper left) can be used to toggle the active project.
+
+### Enforcing two-factor authentication
+
+The organization owner can enforce two-factor authentication by checking the box at the top of the page.
+
+Users will be prompted to complete the two-factor authentation enrolment before they can undertake any further action within the dashboard.
+
+### Changing roles
+
+To change an existing user role you must have an organization owner or administrator remove and re-add you with the appropriate role.
+
+
+### Role permissions
+
+|                            | Developer   | Content manager | Read only | Administrator | Organization owner |
+| ----------- | :----: | :----: | :----: | :----: | :----: |
+| View project configuration | ✅          |                  | ✅        | ✅            | ✅                 |
+| Create project             | ✅          |                  |           | ✅            | ✅                 |
+| Edit project               | ✅          |                  |           | ✅            | ✅                 |
+| Delete project             |             |                  |           | ✅           | ✅                 |
+| View project tokens        | ✅          |                  | ✅        | ✅            | ✅                  |
+| View domains               | ✅          |                  | ✅        | ✅            | ✅                  |
+| Manage certificates        | ✅          |                  |           | ✅            | ✅                  |
+| Create domain              | ✅          |                  |           | ✅            | ✅                  |
+| Manage forms               | ✅          | ✅               |           | ✅            | ✅                  |
+| View form submissions      | ✅          | ✅               |           | ✅            | ✅                  |
+| View content and media     | ✅          | ✅               | ✅        | ✅            | ✅                  |
+| View content revisions     | ✅          | ✅               | ✅        | ✅            | ✅                  |
+| Create content and media   | ✅          | ✅               |           | ✅            | ✅                  |
+| Unpublish content          | ✅          | ✅               |           | ✅            | ✅                  |
+| Delete content             | ✅          | ✅               |           | ✅            | ✅                  |
+| Revert revisions           | ✅          | ✅               |           | ✅            | ✅                  |
+| Upload files via UI        | ✅          | ✅               |           | ✅            | ✅                  |
+| Upload archive via UI      |             | ✅               |           | ✅            | ✅                  |
+| Use WYSIWYG editor         | ✅          | ✅               |           | ✅            | ✅                  |
+| Use code editor            | ✅          | ✅               |           | ✅            | ✅                  |
+| View search configuration  | ✅          |                  | ✅        | ✅            | ✅                  |
+| Manage search              | ✅          |                  |           | ✅            | ✅                  |
+| Clear search index         | ✅          |                  |           | ✅            | ✅                  |
+| View alert configuration   | ✅          | ✅               | ✅        | ✅            | ✅                  |
+| Use alert editor           | ✅          | ✅               |           | ✅            | ✅                  |
+| View custom headers        | ✅          |                  | ✅        | ✅            | ✅                  |
+| Use custom headers editor  | ✅          |                  |           | ✅            | ✅                  |
+| View rules configuration   | ✅          |                  | ✅        | ✅            | ✅                  |
+| Manage rules               | ✅          |                  |           | ✅            | ✅                  |
+| View crawler config        | ✅          |                  | ✅        | ✅            | ✅                  |
+| Create crawler             |             |                  |           | ✅            | ✅                  |
+| Edit crawler config        | ✅          |                  |           | ✅            | ✅                  |
+| Trigger crawls             | ✅          |                  |           | ✅            | ✅                  |
+| View crawl history         | ✅          |                  | ✅        | ✅            | ✅                  |
+| View team members          | ✅          | ✅               | ✅        | ✅            | ✅                  |
+| Manage team members        |             |                  |           | ✅            | ✅                  |
+| Manage subscription        |             |                  |           | ✅            | ✅                  |
+| Enforce TFA                |             |                  |           |               | ✅                  |
+| Reset team member TFA¹     |             |                  |           |               | ✅                  |
+
+¹ via support desk. Additional verification processes apply.

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -6,7 +6,7 @@ sidebar_label: Welcome
 
 Quant is a static-web CDN designed to provide you the benefits of the static web without the complexity of rearchitecting your solution. Quant provides integrations for popular CMS and static generators to ensure your content and development workflows continue without interruption.
 
-While the fundamental idea is to ensure a low-barrier to enjoy the many [benefits of static web](https://www.quantcdn.io/benefits), there are rich [APIs](/docs/api/get-started-content) for developers to create their own custom integrations.
+While the fundamental idea is to ensure a low barrier to enjoy the many [benefits of static web](https://www.quantcdn.io/benefits), there are rich [APIs](/docs/api/get-started-content) for developers to create their own custom integrations.
 
 ## Discover Quant
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -6,7 +6,7 @@ sidebar_label: Welcome
 
 Quant is a static-web CDN designed to provide you the benefits of the static web without the complexity of rearchitecting your solution. Quant provides integrations for popular CMS and static generators to ensure your content and development workflows continue without interruption.
 
-While the fundamental idea is to ensure a low barrier to enjoy the many [benefits of static web](https://www.quantcdn.io/benefits), there are rich [APIs](/docs/api/get-started-content) for developers to create their own custom integrations.
+While the fundamental idea is to ensure a low barrier to enjoy the many [benefits of the static web](https://www.quantcdn.io/benefits), there are rich [APIs](/docs/api/get-started-content) for developers to create their own custom integrations.
 
 ## Discover Quant
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -6,7 +6,7 @@ sidebar_label: Welcome
 
 Quant is a static-web CDN designed to provide you the benefits of the static web without the complexity of rearchitecting your solution. Quant provides integrations for popular CMS and static generators to ensure your content and development workflows continue without interruption.
 
-While the fundamental idea is to ensure a low-barrier to enjoy the many [benefits of static web](https://www.quantcdn.io/benefits), there are rich [APIs](/docs/api/get-started) for developers to create their own custom integrations.
+While the fundamental idea is to ensure a low-barrier to enjoy the many [benefits of static web](https://www.quantcdn.io/benefits), there are rich [APIs](/docs/api/get-started-content) for developers to create their own custom integrations.
 
 ## Discover Quant
 
@@ -57,4 +57,4 @@ You can use the [Quant CLI tool](/docs/cli/get-started) to help automate integra
 It is also capable of [crawling and migrating](/docs/cli/crawler) an entire site to Quant in minutes.
 
 ### API
-To get started with the Quant API, learn how to [authenticate](/docs/api/get-started#make-a-request), [seed content](/docs/api/get-started#sending-content-to-the-api) and move into advanced topics like managing workflows and content states.
+To get started with the Quant API, learn how to [authenticate](/docs/api/get-started-content#make-a-request), [seed content](/docs/api/get-started-content#sending-content-to-the-api) and move into advanced topics like managing workflows and content states.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,7 +64,7 @@ module.exports = {
                     title: 'Developers',
                     items: [{
                             label: 'API',
-                            to: 'docs/api/get-started',
+                            to: 'docs/api/get-started-content',
                         },
                         {
                             label: 'CLI',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,7 +33,7 @@ module.exports = {
                 { to: 'docs/integrations/overview', label: 'Integrations', position: 'left' },
                 { to: 'docs/dashboard/get-started', label: 'Dashboard', position: 'left' },
                 { to: 'docs/cli/get-started', label: 'CLI', position: 'left' },
-                { to: 'docs/api/get-started', label: 'API', position: 'left' },
+                { to: 'docs/api/get-started-content', label: 'API', position: 'left' },
                 {
                     href: 'https://www.quantcdn.io',
                     label: 'quantcdn.io',

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,7 +37,8 @@ module.exports = {
       'cli/continuous-integration'
     ],
     'API': [
-      'api/get-started',
+      'api/get-started-content',
+      'api/get-started-projects',
       'api/search',
       'api/client-workflow'
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,7 @@ module.exports = {
       'dashboard/custom-http-headers',
       'dashboard/search',
       'dashboard/forms',
+      'dashboard/team',
       'dashboard/s3-sync',
     ],
     'CLI': [


### PR DESCRIPTION
* Splits API page into 2x (Project API vs. Content API)
* Added links to OpenAPI schemas
* Added new Team management content

Team management: https://edge.docs.quantcdn.io/docs/dashboard/team
Content API: https://edge.docs.quantcdn.io/docs/api/get-started-content
Project API: https://edge.docs.quantcdn.io/docs/api/get-started-projects